### PR TITLE
Changed image fragments to _noBase64 to fix image blur

### DIFF
--- a/src/components/about/AboutContainer.js
+++ b/src/components/about/AboutContainer.js
@@ -19,7 +19,7 @@ const ABOUT_QUERY = graphql`
               publicURL
               childImageSharp {
                 fluid {
-                  ...GatsbyImageSharpFluid_withWebp
+                  ...GatsbyImageSharpFluid_withWebp_noBase64
                 }
               }
             }

--- a/src/components/header/HeaderContainer.js
+++ b/src/components/header/HeaderContainer.js
@@ -16,7 +16,7 @@ const HEADER_QUERY = graphql`
               publicURL
               childImageSharp {
                 fluid {
-                  ...GatsbyImageSharpFluid_withWebp
+                  ...GatsbyImageSharpFluid_withWebp_noBase64
                 }
               }
             }

--- a/src/components/hero-section/HeroSectionContainer.js
+++ b/src/components/hero-section/HeroSectionContainer.js
@@ -15,7 +15,7 @@ const HERO_SECTION_QUERY = graphql`
             headerBackgroundImage {
               childImageSharp {
                 fluid {
-                  ...GatsbyImageSharpFluid_withWebp
+                  ...GatsbyImageSharpFluid_withWebp_noBase64
                 }
               }
             }

--- a/src/components/main-content/MainContentContainer.js
+++ b/src/components/main-content/MainContentContainer.js
@@ -17,7 +17,7 @@ const MAIN_CONTENT_QUERY = graphql`
             mainImage {
               childImageSharp {
                 fluid {
-                  ...GatsbyImageSharpFluid_withWebp
+                  ...GatsbyImageSharpFluid_withWebp_noBase64
                 }
               }
             }
@@ -27,7 +27,7 @@ const MAIN_CONTENT_QUERY = graphql`
               serviceImage {
                 childImageSharp {
                   fluid {
-                    ...GatsbyImageSharpFluid_withWebp
+                    ...GatsbyImageSharpFluid_withWebp_noBase64
                   }
                 }
               }

--- a/src/components/services/ServicesPageContainer.js
+++ b/src/components/services/ServicesPageContainer.js
@@ -20,7 +20,7 @@ const SERVICES_PAGE_QUERY = graphql`
               serviceImage {
                 childImageSharp {
                   fluid {
-                    ...GatsbyImageSharpFluid_withWebp
+                    ...GatsbyImageSharpFluid_withWebp_noBase64
                   }
                 }
               }


### PR DESCRIPTION
#17 
Replaced the gatsby image query fragment with the noBase64 fragment which changes the images from blur up to fade in.